### PR TITLE
next/theme 적용 및 토글 -> 커스텀 드롭다운 및 시스템 테마 기능 추가

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,19 +1,20 @@
+// app/layout.tsx
 import { CONFIG } from '@/constants/config';
 import '@/styles/globals.css';
 import { pretendard } from '@/fonts/fonts';
-import { cookies } from 'next/headers';
-import Header from '@/components/organisms/Header';
-import Footer from '@/components/organisms/Footer';
+import Header from '@/components/organisms/layout/Header';
+import Footer from '@/components/organisms/layout/Footer';
+import { ThemeProvider } from '@/components/providers/ThemeProvider';
 
-export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const cookieStore = await cookies();
-  const theme = cookieStore.get('theme')?.value === 'dark' ? 'dark' : '';
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang={CONFIG.DEFAULT_LANGUAGE} className={`${pretendard.variable} ${theme}`}>
+    <html lang={CONFIG.DEFAULT_LANGUAGE} className={pretendard.variable} suppressHydrationWarning>
       <body className={`${pretendard.className} layout-wrapper`}>
-        <Header />
-        {children}
-        <Footer />
+        <ThemeProvider>
+          <Header />
+          {children}
+          <Footer />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/atoms/dropdown/DropdownButton.tsx
+++ b/src/components/atoms/dropdown/DropdownButton.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import clsx from 'clsx';
+import { DropdownProps } from './types';
+
+export default function DropdownButton({
+  onClick,
+  children,
+  className,
+  sizeClassName,
+}: DropdownProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={clsx(
+        'focus:outline-none focus:ring-1 focus:ring-primary/50 hover:bg-[var(--color-bg-hover)] rounded',
+        sizeClassName,
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/atoms/dropdown/DropdownItem.tsx
+++ b/src/components/atoms/dropdown/DropdownItem.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import clsx from 'clsx';
+import { DropdownProps } from './types';
+
+export default function DropdownItem({
+  onClick,
+  children,
+  className,
+  sizeClassName,
+}: DropdownProps) {
+  return (
+    <li
+      onClick={onClick}
+      className={clsx('hover:bg-[var(--color-bg-hover)] cursor-pointer', sizeClassName, className)}
+      role="menuitem"
+    >
+      {children}
+    </li>
+  );
+}

--- a/src/components/atoms/dropdown/types.ts
+++ b/src/components/atoms/dropdown/types.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+
+export interface DropdownProps {
+  onClick: () => void;
+  children: React.ReactNode;
+  className?: string;
+  sizeClassName?: string;
+}

--- a/src/components/atoms/image/NotionImage.tsx
+++ b/src/components/atoms/image/NotionImage.tsx
@@ -1,4 +1,3 @@
-// components/atoms/NotionImage.tsx
 import React from 'react';
 
 interface NotionImageProps {

--- a/src/components/molecules/dropdown/IconDropdown/IconDropdownList.tsx
+++ b/src/components/molecules/dropdown/IconDropdown/IconDropdownList.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import DropdownItem from '@/components/atoms/dropdown/DropdownItem';
+import React from 'react';
+import { DropdownOptions } from '@/types/ui/dropdown';
+
+interface IconDropdownListProps {
+  options: DropdownOptions[];
+  onSelect: (value: string) => void;
+}
+
+function IconDropdownList({ options, onSelect }: IconDropdownListProps) {
+  return (
+    <ul className="absolute right-0 mt-2 border border-gray-600 shadow-[var(--shadow)] bg-[var(--color-dropdown-bg)] rounded z-10">
+      {options.map(({ value, label, icon }) => (
+        <DropdownItem
+          key={value}
+          className="flex items-center gap-2"
+          sizeClassName="px-2 py-1.25 w-22"
+          onClick={() => onSelect(value)}
+        >
+          {icon}
+          <span className="flex-1 text-center">{label}</span>
+        </DropdownItem>
+      ))}
+    </ul>
+  );
+}
+
+export default React.memo(IconDropdownList);

--- a/src/components/molecules/dropdown/ThemeDropdown/ThemeDropdown.tsx
+++ b/src/components/molecules/dropdown/ThemeDropdown/ThemeDropdown.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useNextTheme } from '@/hooks/useNextTheme';
+import useDropdown from '@/hooks/useDropDown';
+import DropdownButton from '@/components/atoms/dropdown/DropdownButton';
+import { THEME_OPTIONS } from '@/constants/ThemeOptions';
+import IconDropdownList from '../IconDropdown/IconDropdownList';
+import { useThemeSelect } from '@/hooks/useThemeSelect';
+import { getThemeOption } from '@/utils/ui';
+
+export default function ThemeDropdown() {
+  const { setTheme, mounted, currentTheme } = useNextTheme();
+  const { open, setOpen, dropdownRef } = useDropdown<HTMLDivElement>();
+  const handleSelect = useThemeSelect(setTheme, setOpen);
+
+  if (!mounted) return null;
+
+  return (
+    <div ref={dropdownRef} className="relative text-sm">
+      <DropdownButton
+        className="flex-center-between gap-2"
+        sizeClassName="min-w-15.5 px-1.5 py-1.25"
+        onClick={() => setOpen((prev) => !prev)}
+      >
+        {getThemeOption(currentTheme)?.icon}
+        <span className="capitalize">{currentTheme}</span>
+      </DropdownButton>
+      {open && <IconDropdownList options={THEME_OPTIONS} onSelect={handleSelect} />}
+    </div>
+  );
+}

--- a/src/components/providers/ThemeProvider.tsx
+++ b/src/components/providers/ThemeProvider.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { ThemeProvider as NextThemesProvider } from 'next-themes';
+import { JSX } from 'react';
+
+export function ThemeProvider({ children }: { children: React.ReactNode }): JSX.Element {
+  return <NextThemesProvider attribute="class">{children}</NextThemesProvider>;
+}

--- a/src/constants/ThemeOptions.tsx
+++ b/src/constants/ThemeOptions.tsx
@@ -1,0 +1,8 @@
+import { Sun, Moon, Monitor } from 'lucide-react';
+import { DropdownOptions } from '@/types/ui/dropdown';
+
+export const THEME_OPTIONS: DropdownOptions[] = [
+  { value: 'light', label: 'Light', icon: <Sun className="w-4 h-4" /> },
+  { value: 'dark', label: 'Dark', icon: <Moon className="w-4 h-4" /> },
+  { value: 'system', label: 'System', icon: <Monitor className="w-4 h-4" /> },
+];

--- a/src/hooks/useDropDown.ts
+++ b/src/hooks/useDropDown.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef, useState } from 'react';
+
+const useDropdown = <T extends HTMLElement>() => {
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<T>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  return {
+    open,
+    setOpen,
+    dropdownRef,
+  };
+};
+
+export default useDropdown;

--- a/src/hooks/useNextTheme.ts
+++ b/src/hooks/useNextTheme.ts
@@ -1,0 +1,27 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+
+type UseNextThemeReturn = {
+  setTheme: (theme: string) => void;
+  mounted: boolean;
+  currentTheme: string | undefined;
+  isDark: boolean;
+};
+
+export function useNextTheme(): UseNextThemeReturn {
+  const { resolvedTheme, setTheme, theme: currentTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  return {
+    setTheme,
+    mounted,
+    currentTheme,
+    isDark: resolvedTheme === 'dark',
+  };
+}

--- a/src/hooks/useThemeSelect.ts
+++ b/src/hooks/useThemeSelect.ts
@@ -1,0 +1,14 @@
+import { useCallback } from 'react';
+
+type SetTheme = (value: string) => void;
+type SetOpen = (open: boolean) => void;
+
+export const useThemeSelect = (setTheme: SetTheme, setOpen: SetOpen) => {
+  return useCallback(
+    (value: string) => {
+      setTheme(value);
+      setOpen(false);
+    },
+    [setTheme, setOpen],
+  );
+};

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1,9 +1,12 @@
 @layer components {
+  .flex-center-between {
+    @apply flex items-center justify-between;
+  }
   .layout-wrapper {
     @apply min-h-screen max-w-4xl mx-auto flex flex-col items-center;
   }
   .hover-opacity {
-    @apply hover:opacity-80;
+    @apply hover:opacity-65;
   }
   .p-content {
     @apply py-5 px-3.75;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,7 @@
 @import './components.css';
 @import './theme.css';
 @import './notion.css';
+@custom-variant dark (&:where(.dark, .dark *));
 
 @layer base {
   html {
@@ -20,7 +21,9 @@
 
   html,
   body {
-    @apply transition-colors duration-300 ease-in-out;
+    transition-property: color, background-color;
+    transition-duration: 100ms;
+    transition-timing-function: ease-in;
   }
 
   *,

--- a/src/styles/notion.css
+++ b/src/styles/notion.css
@@ -1,7 +1,10 @@
 .notion-page {
-  padding-inline: 1.25rem !important;
+  padding-inline: 0.9375rem !important;
   width: 100% !important;
   margin: 0 !important;
+}
+.notion-table-of-contents-item {
+  color: var(--color-text) !important;
 }
 
 .notion-code code {
@@ -14,7 +17,7 @@
 .notion-aside-table-of-contents {
   background-color: transparent !important;
   position: fixed !important;
-  top: 8.75rem; /* 140px */
+  top: 5.5rem;
   right: 6.5rem;
 }
 /* TOC 숨김 구간: 1100px ~ 1680px */
@@ -48,9 +51,9 @@
   color: var(--color-text) !important;
   font-family: 'Pretendard', sans-serif !important;
   font-size: 1.1rem !important;
-  transition:
-    background-color 0.3s ease-in-out,
-    color 0.3s ease-in-out !important;
+  transition-property: color, background-color !important;
+  transition-duration: 100ms !important;
+  transition-timing-function: ease-in !important;
   background-color: var(--color-article-bg) !important;
 }
 

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,11 +1,14 @@
 :root {
   --color-bg: #f8f9fa;
+  --color-bg-hover: rgba(0, 0, 0, 0.05);
   --color-text: #374151;
 
   --color-primary: #f1f5f9;
   --color-accent: #e0f2fe;
   --color-accent-text: #1e293b;
   --color-post-bg: #f8f9fa;
+
+  --color-dropdown-bg: #f8f9fa;
 
   --color-tag-default-bg: #d1d5db;
   --color-tag-default-text: #374151;
@@ -42,6 +45,7 @@
 
 html.dark {
   --color-bg: #0f172a;
+  --color-bg-hover: rgba(255, 255, 255, 0.08);
   --color-text: #e2e8f0;
 
   --color-primary: #1e293b;
@@ -49,6 +53,8 @@ html.dark {
 
   --color-accent-text: #f1f5f9;
   --color-post-bg: #1e293b;
+
+  --color-dropdown-bg: #2c2f36;
 
   --color-tag-default-bg: #4b5563;
   --color-tag-default-text: #f3f4f6;

--- a/src/types/ui/dropdown.ts
+++ b/src/types/ui/dropdown.ts
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export type DropdownOptions = {
+  value: 'light' | 'dark' | 'system';
+  label: string;
+  icon: React.ReactNode;
+};

--- a/src/utils/ui.ts
+++ b/src/utils/ui.ts
@@ -1,0 +1,4 @@
+import { THEME_OPTIONS } from '@/constants/ThemeOptions';
+
+export const getThemeOption = (value: string | undefined) =>
+  THEME_OPTIONS.find((option) => option.value === value);


### PR DESCRIPTION
### next/theme 적용 
1. 기존 라이브러리 없이 구현한 테마 기능 next/theme 사용 ( 쿠키 사용 )
2. SSG/SSR 방식 사용시 테마 변경시 Hydration 불일치 발생
3. 첫 화면 다크 모드인데 실제 화면은 라이트 -> 토글 두번 눌러야 모드 바뀜
4. next/theme 공식 문서 참고해 기존 로직에서 해당 라이브러리 사용으로 마이그레이션
5. 홈 화면 클라이언트 컴포넌트에서 useEffect 사용하여 컴포넌트가 완전히 마운트 됬을때 현재 모드에 따라 테마를 화면에 적용 ( 로컬 스토리지 사용 )
6. 라이브러리 사용하여 쉽게 시스템 테마에 따라 테마 적용 추가 
7. useNextTheme 커스텀 훅으로 추상화

### 커스텀 드롭다운 테마 변경 적용
1. 기존 토글 버튼 방식으로 라이트, 다크모드 적용 -> 버튼 클릭시 테마 변경 ( 라이트모드, 다크모드 2가지 방식 )
2. 커스텀 드롭다운 ui 구성으로 수정 -> 아토믹 디자인으로 재사용성 및 가독성 최적화
3. 드롭다운 관련 커스텀 훅 분리하여 가독성 증진, 추상화 및 최적화 
4. useNextTheme 사용하여 시스템, 다크, 라이트 모드 ui 에 적용 및 로직 구현 